### PR TITLE
Removal of master/slave language

### DIFF
--- a/src/rospy/__init__.py
+++ b/src/rospy/__init__.py
@@ -53,7 +53,7 @@ from roslib.msg import Header
 from rospy.client import spin, myargv, init_node, \
     get_published_topics, \
     wait_for_message, \
-    get_master, get_node_proxy,\
+    get_main, get_node_proxy,\
     on_shutdown, \
     get_param, get_param_names, set_param, delete_param, has_param, search_param,\
     sleep, Rate,\
@@ -64,7 +64,7 @@ from rospy.core import is_shutdown, signal_shutdown, \
     parse_rosrpc_uri
 from rospy.exceptions import *
 from rospy.msg import AnyMsg
-from rospy.msproxy import NodeProxy, MasterProxy
+from rospy.msproxy import NodeProxy, MainProxy
 from rospy.names import get_name, get_caller_id, get_namespace, resolve_name, remap_name
 from rospy.rostime import Time, Duration, get_rostime, get_time
 from rospy.service import ServiceException, ServiceDefinition
@@ -81,7 +81,7 @@ __all__ = [
     'spin',
     'myargv',
     'init_node',
-    'get_master',
+    'get_main',
     'get_published_topics',
     'wait_for_service',
     'on_shutdown',
@@ -106,7 +106,7 @@ __all__ = [
     'logwarn', 'loginfo',
     'logout', 'logerr', 'logfatal',
     'parse_rosrpc_uri',
-    'MasterProxy',
+    'MainProxy',
     'NodeProxy',    
     'ROSException',
     'ROSSerializationException',

--- a/src/rospy/core.py
+++ b/src/rospy/core.py
@@ -222,7 +222,7 @@ def logfatal(msg, *args):
 #########################################################
 # CONSTANTS
 
-MASTER_NAME = "master" #master is a reserved node name for the central master
+MASTER_NAME = "main" #main is a reserved node name for the central main
 
 def get_ros_root(required=False, env=None):
     """

--- a/src/rospy/impl/masterslave.py
+++ b/src/rospy/impl/masterslave.py
@@ -30,9 +30,9 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# Revision $Id: masterslave.py 10462 2010-07-21 20:42:06Z kwc $
+# Revision $Id: mainsubordinate.py 10462 2010-07-21 20:42:06Z kwc $
 """
-Internal use: ROS Node (Slave) API. 
+Internal use: ROS Node (Subordinate) API. 
 
 The Node API is implemented by the L{ROSHandler}.
 
@@ -87,13 +87,13 @@ VAL = 2
 def is_publishers_list(paramName):
     return ('is_publishers_list', paramName)
 
-_logger = logging.getLogger("rospy.impl.masterslave")
+_logger = logging.getLogger("rospy.impl.mainsubordinate")
 
 LOG_API = True
 
 def apivalidate(error_return_value, validators=()):
     """
-    ROS master/slave arg-checking decorator. Applies the specified
+    ROS main/subordinate arg-checking decorator. Applies the specified
     validator to the corresponding argument and also remaps each
     argument to be the value returned by the validator.  Thus,
     arguments can be simultaneously validated and canonicalized prior
@@ -162,7 +162,7 @@ def apivalidate(error_return_value, validators=()):
 
 class ROSHandler(XmlRpcHandler):
     """
-    Base handler for both slave and master nodes. API methods
+    Base handler for both subordinate and main nodes. API methods
     generally provide the capability for establishing point-to-point
     connections with other nodes.
     
@@ -170,21 +170,21 @@ class ROSHandler(XmlRpcHandler):
     to what is added here. 
     """
     
-    def __init__(self, name, master_uri):
+    def __init__(self, name, main_uri):
         """
-        Base constructor for ROS nodes/masters
+        Base constructor for ROS nodes/mains
         @param name: ROS name of this node
         @type  name: str
-        @param master_uri: URI of master node, or None if this node is the master
-        @type  master_uri: str
+        @param main_uri: URI of main node, or None if this node is the main
+        @type  main_uri: str
         """
         super(ROSHandler, self).__init__()
-        self.masterUri = master_uri
+        self.mainUri = main_uri
         self.name = name
         self.uri = None
         self.done = False
 
-        # initialize protocol handlers. The master will not have any.
+        # initialize protocol handlers. The main will not have any.
         self.protocol_handlers = []
         handler = rospy.impl.tcpros.get_tcpros_handler()
         if handler is not None:
@@ -197,7 +197,7 @@ class ROSHandler(XmlRpcHandler):
 
     def _is_registered(self):
         """
-        @return: True if slave API is registered with master.
+        @return: True if subordinate API is registered with main.
         @rtype: bool
         """
         if self.reg_man is None:
@@ -216,7 +216,7 @@ class ROSHandler(XmlRpcHandler):
         self.uri = uri
         #connect up topics in separate thread
         if self.reg_man:
-            t = threading.Thread(target=self.reg_man.start, args=(uri, self.masterUri))
+            t = threading.Thread(target=self.reg_man.start, args=(uri, self.mainUri))
             rospy.core._add_shutdown_thread(t)
             t.start()
 
@@ -315,18 +315,18 @@ class ROSHandler(XmlRpcHandler):
         return 1, "bus info", get_topic_manager().get_pub_sub_info()
     
     @apivalidate('')
-    def getMasterUri(self, caller_id):
+    def getMainUri(self, caller_id):
         """
-        Get the URI of the master node.
+        Get the URI of the main node.
         @param caller_id: ROS caller id    
         @type  caller_id: str
-        @return: [code, msg, masterUri]
+        @return: [code, msg, mainUri]
         @rtype: [int, str, str]
         """
-        if self.masterUri:
-            return 1, self.masterUri, self.masterUri
+        if self.mainUri:
+            return 1, self.mainUri, self.mainUri
         else:
-            return 0, "master URI not set", ""
+            return 0, "main URI not set", ""
 
     def _shutdown(self, reason=''):
         """
@@ -455,7 +455,7 @@ class ROSHandler(XmlRpcHandler):
     @apivalidate(-1, (global_name('parameter_key'), None))
     def paramUpdate(self, caller_id, parameter_key, parameter_value):
         """
-        Callback from master of current publisher list for specified topic.
+        Callback from main of current publisher list for specified topic.
         @param caller_id: ROS caller id
         @type  caller_id: str
         @param parameter_key str: parameter name, globally resolved
@@ -475,7 +475,7 @@ class ROSHandler(XmlRpcHandler):
     @apivalidate(-1, (is_topic('topic'), is_publishers_list('publishers')))
     def publisherUpdate(self, caller_id, topic, publishers):
         """
-        Callback from master of current publisher list for specified topic.
+        Callback from main of current publisher list for specified topic.
         @param caller_id: ROS caller id
         @type  caller_id: str
         @param topic str: topic name

--- a/src/rospy/impl/msnode.py
+++ b/src/rospy/impl/msnode.py
@@ -46,7 +46,7 @@ from rospy.names import _set_caller_id, get_namespace, get_caller_id, scoped_nam
 
 class ROSNode(roslib.xmlrpc.XmlRpcNode):
     """
-    Base ROS node, aka a slave node. Enables basic functionality for
+    Base ROS node, aka a subordinate node. Enables basic functionality for
     the connection of topics with other nodes.  ROSNode is initialized
     when the uri field has a value.
     """

--- a/src/rospy/impl/simtime.py
+++ b/src/rospy/impl/simtime.py
@@ -55,8 +55,8 @@ def _is_use_simtime():
     # in order to prevent circular dependencies, this does not use the
     # builtin libraries for interacting with the parameter server, at least
     # until I reorganize the client vs. internal APIs better.
-    master_uri = roslib.rosenv.get_master_uri()
-    m = rospy.core.xmlrpcapi(master_uri)
+    main_uri = roslib.rosenv.get_main_uri()
+    m = rospy.core.xmlrpcapi(main_uri)
     code, msg, val = m.getParam(rospy.names.get_caller_id(), _USE_SIMTIME)
     if code == 1 and val:
         return True

--- a/src/rospy/impl/tcpros_base.py
+++ b/src/rospy/impl/tcpros_base.py
@@ -82,7 +82,7 @@ def _is_use_tcp_keepalive():
     # in order to prevent circular dependencies, this does not use the
     # builtin libraries for interacting with the parameter server
     import roslib.rosenv
-    m = rospy.core.xmlrpcapi(roslib.rosenv.get_master_uri())
+    m = rospy.core.xmlrpcapi(roslib.rosenv.get_main_uri())
     code, msg, val = m.getParam(rospy.names.get_caller_id(), _PARAM_TCP_KEEPALIVE)
     _use_tcp_keepalive = val if code == 1 else True
     return _use_tcp_keepalive 

--- a/src/rospy/impl/tcpros_service.py
+++ b/src/rospy/impl/tcpros_service.py
@@ -90,7 +90,7 @@ def wait_for_service(service, timeout=None):
     @raise ROSInterruptException: if shutdown interrupts wait
     """
     def contact_service(resolved_name, timeout=10.0):
-        code, _, uri = master.lookupService(rospy.names.get_caller_id(), resolved_name)
+        code, _, uri = main.lookupService(rospy.names.get_caller_id(), resolved_name)
         if False and code == 1:
             return True
         elif True and code == 1:
@@ -113,7 +113,7 @@ def wait_for_service(service, timeout=None):
     if timeout == 0.:
         raise ValueError("timeout must be non-zero")
     resolved_name = rospy.names.resolve_name(service)
-    master = roslib.scriptutil.get_master()    
+    main = roslib.scriptutil.get_main()    
     first = False
     if timeout:
         timeout_t = time.time() + timeout
@@ -445,9 +445,9 @@ class ServiceProxy(_Service):
         if 1: #always do lookup for now, in the future we need to optimize
             try:
                 try:
-                    code, msg, self.uri = roslib.scriptutil.get_master().lookupService(rospy.names.get_caller_id(), self.resolved_name)
+                    code, msg, self.uri = roslib.scriptutil.get_main().lookupService(rospy.names.get_caller_id(), self.resolved_name)
                 except:
-                    raise ServiceException("unable to contact master")
+                    raise ServiceException("unable to contact main")
                 if code != 1:
                     logger.error("[%s]: lookup service failed with message [%s]", self.resolved_name, msg)
                     raise ServiceException("service [%s] unavailable"%self.resolved_name)
@@ -456,9 +456,9 @@ class ServiceProxy(_Service):
                 try:
                     rospy.core.parse_rosrpc_uri(self.uri)
                 except rospy.impl.validators.ParameterInvalid:
-                    raise ServiceException("master returned invalid ROSRPC URI: %s"%self.uri)
+                    raise ServiceException("main returned invalid ROSRPC URI: %s"%self.uri)
             except socket.error as e:
-                logger.error("[%s]: socket error contacting service, master is probably unavailable",self.resolved_name)
+                logger.error("[%s]: socket error contacting service, main is probably unavailable",self.resolved_name)
         return self.uri
 
     def call(self, *args, **kwds):
@@ -570,8 +570,8 @@ class ServiceImpl(_Service):
             #TODO: make service manager configurable            
             get_service_manager().unregister(self.resolved_name, self)
         except Exception as e:
-            logerr("Unable to unregister with master: "+traceback.format_exc())
-            raise ServiceException("Unable to connect to master: %s"%e)
+            logerr("Unable to unregister with main: "+traceback.format_exc())
+            raise ServiceException("Unable to connect to main: %s"%e)
 
     def spin(self):
         """

--- a/src/rospy/msproxy.py
+++ b/src/rospy/msproxy.py
@@ -32,9 +32,9 @@
 #
 # Revision $Id: msproxy.py 9434 2010-04-28 00:20:16Z kwc $
 """
-Master/Slave XML-RPC Wrappers.
+Main/Subordinate XML-RPC Wrappers.
 
-The L{NodeProxy} and L{MasterProxy} simplify usage of master/slave
+The L{NodeProxy} and L{MainProxy} simplify usage of main/subordinate
 APIs by automatically inserting the caller ID and also adding python
 dictionary accessors on the parameter server.
 """
@@ -44,7 +44,7 @@ import rospy.exceptions
 import rospy.names
 
 import rospy.impl.paramserver
-import rospy.impl.masterslave
+import rospy.impl.mainsubordinate
 
 class NodeProxy(object):
     """
@@ -58,7 +58,7 @@ class NodeProxy(object):
         
     def __getattr__(self, key): #forward api calls to target
         f = getattr(self.target, key)
-        remappings = rospy.impl.masterslave.ROSHandler.remappings(key)
+        remappings = rospy.impl.mainsubordinate.ROSHandler.remappings(key)
         def wrappedF(*args, **kwds):
             args = [rospy.names.get_caller_id(),]+list(args)
             #print "Remap indicies", remappings
@@ -69,7 +69,7 @@ class NodeProxy(object):
             return f(*args, **kwds)
         return wrappedF
 
-_master_arg_remap = { 
+_main_arg_remap = { 
     'deleteParam': [0], # remap key
     'setParam': [0], # remap key
     'getParam': [0], # remap key
@@ -88,32 +88,32 @@ _master_arg_remap = {
     'getPublishedTopics': [0], # remap subgraph
     }
     
-class MasterProxy(NodeProxy):
+class MainProxy(NodeProxy):
     """
-    Convenience wrapper for ROS master API and XML-RPC
-    implementation. The Master API methods can be invoked on this
+    Convenience wrapper for ROS main API and XML-RPC
+    implementation. The Main API methods can be invoked on this
     object and will be forwarded appropriately. Names in arguments
     will be remapped according to current node settings. Provides
     dictionary-like access to parameter server, e.g.::
     
-      master[key] = value
+      main[key] = value
 
     """
 
     def __init__(self, uri):
         """
-        Constructor for wrapping a remote master instance.
-        @param uri: XML-RPC URI of master
+        Constructor for wrapping a remote main instance.
+        @param uri: XML-RPC URI of main
         @type  uri: str
         """
-        super(MasterProxy, self).__init__(uri)
+        super(MainProxy, self).__init__(uri)
 
     def __getattr__(self, key): #forward api calls to target
         f = getattr(self.target, key)
-        if key in _master_arg_remap:
-            remappings = _master_arg_remap[key]
+        if key in _main_arg_remap:
+            remappings = _main_arg_remap[key]
         else:
-            remappings = rospy.impl.masterslave.ROSHandler.remappings(key)
+            remappings = rospy.impl.mainsubordinate.ROSHandler.remappings(key)
         def wrappedF(*args, **kwds):
             args = [rospy.names.get_caller_id(),]+list(args)
             #print "Remap indicies", remappings

--- a/src/rospy/names.py
+++ b/src/rospy/names.py
@@ -231,7 +231,7 @@ def scoped_name(caller_id, name):
 ###################################################
 # Name validators      ############################
 
-#Technically XMLRPC will never send a None, but I don't want to code masterslave.py to be
+#Technically XMLRPC will never send a None, but I don't want to code mainsubordinate.py to be
 #XML-RPC specific in this way.
 
 def valid_name_validator_resolved(param_name, param_value, caller_id):

--- a/src/rospy/service.py
+++ b/src/rospy/service.py
@@ -100,7 +100,7 @@ class ServiceManager(object):
     
     def register(self, resolved_service_name, service):
         """
-        Register service with ServiceManager and ROS master
+        Register service with ServiceManager and ROS main
         @param resolved_service_name: name of service (resolved)
         @type  resolved_service_name: str
         @param service: Service to register
@@ -121,7 +121,7 @@ class ServiceManager(object):
         
     def unregister(self, resolved_service_name, service):
         """
-        Unregister service with L{ServiceManager} and ROS Master
+        Unregister service with L{ServiceManager} and ROS Main
         @param resolved_service_name: name of service
         @type  resolved_service_name: str
         @param service: service implementation


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.